### PR TITLE
Fix activity popup dismiss crash.

### DIFF
--- a/ios/Plugin/IOSActivityNativePopupProvider.mm
+++ b/ios/Plugin/IOSActivityNativePopupProvider.mm
@@ -174,7 +174,9 @@ IOSActivityNativePopupProvider::showPopup( lua_State *L )
 					Lua::DispatchEvent( L, listenerRef, 0 );
 
 					// Free native reference to listener
-					Lua::DeleteRef( L, listenerRef );
+					if ( !activityType || completed ) {
+						Lua::DeleteRef( L, listenerRef );
+					}
 				};
 			}
 


### PR DESCRIPTION
The crash only happened when opening the activity popup + opening an activity (eg. sms, email) and dismissing them both without sending anything.